### PR TITLE
add a note on TOP under 'persistent DOIs'

### DIFF
--- a/editorial.tex
+++ b/editorial.tex
@@ -123,16 +123,23 @@ programs, as often this can take days to recreate the computational
 environment, and computations could take many months to complete.
 Furthermore, this report will not prevent publication of a manuscript, as the current policy at Nature is not mandatory.
 This effort corresponds to an assessment of code availability as suggested by
-the Transparency and Openness Promotion Guidelines \cite{Nosek2015}, but
+the Transparency and Openness Promotion (TOP) Guidelines \cite{Nosek2015}, and
 extends the scope with concrete feedback on core aspects of long-term reusability.
-
 
 \subsection*{What should be shared?}
 
-It may not be obvious what to share, especially for complex projects with many collaborators.  Ideally,
-you should share as much code and data to allow others to reproduce
-your work,  but this may not be possible/practical.  However, it
-is expected that you will share key parts of the work, e.g. implementations of novel algorithms or analysis.  By getting into the habit of sharing as much as possible, not only do you help others who wish to reproduce your work, you will be helping other members of your laboratory, or even yourself in the future.  By sharing your code publicly, you are more likely to write higher-quality code \cite{Easterbrook2014}, and you will know where to find it after you've moved on from the project \cite{Halchenko2015}, rather than the code disappearing on a colleague's laptop when they leave your group. In addition, as advocated by Claerbout and Donoho, for computational sciences the scholarship is not the article, the "scholarship is the complete software [...]" \cite{claerbout_electronic_1992,donoho_invitation_2010}.
+It may not be obvious what to share, especially for complex projects with many
+collaborators.  Ideally, you should share as much code and data to allow others to
+reproduce your work,  but this may not be possible/practical.  However, it
+is expected that you will share key parts of the work, e.g. implementations of
+novel algorithms or analysis.  By getting into the habit of sharing as much as
+possible, not only do you help others who wish to reproduce your work, you will be
+helping other members of your laboratory, or even yourself in the future.  By
+sharing your code publicly, you are more likely to write higher-quality code
+\cite{Easterbrook2014}, and you will know where to find it after you've moved on
+from the project \cite{Halchenko2015}, rather than the code disappearing on a
+colleague's laptop when they leave your group. In addition, as advocated by
+Claerbout and Donoho, for computational sciences the scholarship is not the article, the "scholarship is the complete software [...]" \cite{claerbout_electronic_1992,donoho_invitation_2010}.
 
 \subsection*{Simple steps to help you share your code}
 
@@ -153,11 +160,11 @@ not just at the end when you wish to publish your results. Guidelines similar to
   of publication. It also makes it easy for others to contribute to your code, and to adapt it for their own uses. 
 
 \item [Persistent URLs] Generate stable URLs (such as a DOI) for key
-  versions of your software.  Unique identifiers are a key element in demonstrating the integrity and reproducibiltiy of research \cite{vasilevsky2013reproducibility}. For code, these can be obtained freely and routinely with sites such as \url{http://zenodo.org} and \url{http://figshare.com}.  If your work includes computer models of neural systems, you may wish to consider depositing these models in established repositories such as ModelDB (\url{https://senselab.med.yale.edu/}) or \url{http://opensourcebrain.org} or NITRC \cite{poline_software_2014}. Some of these sites allow for private sharing of repositories with anonymous peer reviewers.
+  versions of your software.  Unique identifiers are a key element in demonstrating the integrity and reproducibility of research \cite{vasilevsky2013reproducibility}. For code, these can be obtained freely and routinely with sites such as \url{http://zenodo.org} and \url{http://figshare.com}.  If your work includes computer models of neural systems, you may wish to consider depositing these models in established repositories such as ModelDB (\url{https://senselab.med.yale.edu/}) or \url{http://opensourcebrain.org} or NITRC \cite{poline_software_2014}. Some of these sites allow for private sharing of repositories with anonymous peer reviewers. Journal articles that include a persistent URL to code deposited in a trusted repository meet the requirements of level two of the 'analytic methods (code) transparency' standard of the TOP guidelines \cite{Nosek2015}.
 
 
 \item [License] Choose a suitable license for your code to assert how
-  you wish others to reuse your code  For example, to maximise reuse,
+  you wish others to reuse your code  For example, to maximize reuse,
   you may wish to use a permissive license such as MIT or BSD
   \cite{Stodden2009}.  Licenses are also important to protect you from
   others misusing your code.  Visit \url{http://choosealicense.com/}
@@ -201,13 +208,13 @@ not just at the end when you wish to publish your results. Guidelines similar to
 
 Varsha Khodiyar 2015 Code Sharing - read our tips and share your own. Scientific Data Blog, February 19, 2015. \url{http://blogs.nature.com/scientificdata/2015/02/19/code-sharing-tips/}
 
-Leveque, Randall 2012. Top Ten Reasons to Not Share Your Code (and why you should anyway). \url{http://faculty.washington.edu/rjl/pubs/topten/topten.pdf}
+Leveque, Randall 2013. Top Ten Reasons to Not Share Your Code (and why you should anyway). SIAM News, April 2013, \url{http://sinews.siam.org/DetailsPage/tabid/607/ArticleID/386/Top-Ten-Reasons-To-Not-Share-Your-Code-and-why-you-should-anyway.aspx}
 
 Stodden, V. \& Miguez, S., 2014. Best Practices for Computational Science: Software Infrastructure and Environments for Reproducible and Extensible Research. Journal of Open Research Software. 2(1), p.e21. DOI: \url{http://doi.org/10.5334/jors.ay}
 
-Stodden, V., Leisch, F., \& Peng R. (Eds.). (2014). Implementing Reproducible Research. CRC press, Chapman and Hall. \cite{victoria_stodden_implementing_2014}
+Stodden, V., Leisch, F., \& Peng R. (Eds.). (2014). Implementing Reproducible Research. CRC press, Chapman and Hall. 
 
-Halchenko, Y. O. and Hanke, M. (2015). Four aspects to make science open ``by design'' and not as an after-thought. GigaScience, 4. DOI: \url{http://doi.org/10.1186/s13742-015-0072-7} \cite{Halchenko2015}
+Halchenko, Y. O. and Hanke, M. (2015). Four aspects to make science open ``by design'' and not as an after-thought. GigaScience, 4. DOI: \url{http://doi.org/10.1186/s13742-015-0072-7}
 
 \subsection*{Online communities discussing code sharing (note to editor: please make this a box feature)}
 


### PR DESCRIPTION
Following up on the general mention of the TOP guidelines that @hanke added at https://github.com/sje30/sharing-report/commit/2088141086fcb561f1885c10218d907131bfdf02, I added a line in the 'persistent URL' section to refer to the specific level and standard of the TOP guideline that this paper is most relevant to. Plus some other minor edits elsewhere. 
